### PR TITLE
FinalProject.Window: Set flags

### DIFF
--- a/FinalProject/include/Window.hpp
+++ b/FinalProject/include/Window.hpp
@@ -89,4 +89,26 @@ class Window {
      * @return true if maximum size changed else false
      */
     bool set_size_maximum(int width, int height);
+
+    /**
+     * @brief Set flags on active window
+     *
+     * Will set a flag or flags for the active window. Will fail if you try to
+     * set FLAG_WINDOW_TRANSPARENT, FLAG_WINDOW_HIGHDPI, or FLAG_MSAA_4X_HINT,
+     * as those can only be set before window creation
+     *
+     * @return true if success
+     */
+    bool set_flag(ConfigFlags flags_to_set);
+
+    /**
+     * @brief Removes state flags from window
+     *
+     * Depending on which overload is used, this function will remove all flags,
+     * or specified flags.
+     *
+     * @return true if the flag has been removed
+     */
+    bool remove_flags();
+    bool remove_flags(ConfigFlags flags_to_remove);
 };

--- a/FinalProject/src/Window.cpp
+++ b/FinalProject/src/Window.cpp
@@ -246,3 +246,57 @@ bool Window::set_size_maximum(int width, int height) {
 
     return (width == get_maximum_width() && height == get_maximum_height());
 }
+
+
+bool Window::set_flag(ConfigFlags flags_to_set) {
+    if (flags_to_set & FLAG_WINDOW_TRANSPARENT) {
+        TraceLog(LOG_WARNING, "Transparent window can only be set on initialization");
+        return false;
+    }
+
+    if (flags_to_set & FLAG_WINDOW_HIGHDPI) {
+        TraceLog(LOG_WARNING, "Highdpi can only be set on initialization");
+        return false;
+    }
+
+    if (flags_to_set & FLAG_MSAA_4X_HINT) {
+        TraceLog(LOG_WARNING, "MSAA 4X can only be set on initialization");
+        return false;
+    }
+
+
+    if (is_test_mode) {
+        flags = static_cast<ConfigFlags>(flags | flags_to_set);
+    } else {
+        SetWindowState(flags_to_set);
+        flags = get_flags();
+    }
+
+    return (flags & flags_to_set) == flags_to_set;
+}
+
+
+bool Window::remove_flags() {
+    if (flags == 0) {
+        TraceLog(LOG_WARNING, "No flags set");
+        return false;
+    }
+
+    ClearWindowState(flags);
+    flags = get_flags();
+
+    return flags == 0;
+}
+
+
+bool Window::remove_flags(ConfigFlags flags_to_remove) {
+    if (!(flags & flags_to_remove)) {
+        TraceLog(LOG_WARNING, "Trying to remove flags that aren't set");
+        return false;
+    }
+
+    ClearWindowState(flags_to_remove);
+    flags = static_cast<ConfigFlags>(flags & ~flags_to_remove);
+
+    return (flags & flags_to_remove) == 0;
+}

--- a/FinalProject/test/test.cpp
+++ b/FinalProject/test/test.cpp
@@ -118,4 +118,90 @@ TEST_SUITE("Window Properties") {
             CHECK_FALSE(window.set_size_maximum(50, 50));
         }
     }
+
+    TEST_CASE("Add flags to initialized window") {
+        const bool test_mode = true;
+        Window window(test_mode);
+
+        SUBCASE("Adding test flags - valid") {
+            ConfigFlags test_flags = static_cast<ConfigFlags>(
+                FLAG_VSYNC_HINT | FLAG_FULLSCREEN_MODE);
+
+            CHECK(window.set_flag(test_flags));
+
+            auto enabled_flags = window.get_enabled_flags();
+            CHECK_EQ(enabled_flags.size(), 2);
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "V-Sync") != enabled_flags.end()));
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "Fullscreen") != enabled_flags.end()));
+        }
+
+        SUBCASE("Adding test flags - invalid") {
+            ConfigFlags test_flags = static_cast<ConfigFlags>(
+                FLAG_MSAA_4X_HINT | FLAG_VSYNC_HINT);
+
+            CHECK_FALSE(window.set_flag(test_flags));
+
+            auto enabled_flags = window.get_enabled_flags();
+            CHECK_NE(enabled_flags.size(), 1);
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "V-Sync") == enabled_flags.end()));
+        }
+    }
+
+    /* TODO (coughlih3099): Update this test once the ability to set flags is
+     * added
+    TEST_CASE("Remove flags from default window") {
+        const bool test_mode = true;
+        Window window(test_mode);
+
+        CHECK_FALSE(window.remove_flags());
+
+        SUBCASE("Add a flag and then remove") {
+        }
+    }
+    */
+
+    TEST_CASE("Remove flags from window initialized with flags") {
+        const int test_width = 800;
+        const int test_height = 600;
+        ConfigFlags test_flags = static_cast<ConfigFlags>(FLAG_FULLSCREEN_MODE |
+                                                          FLAG_WINDOW_ALWAYS_RUN |
+                                                          FLAG_VSYNC_HINT);
+        const std::string test_title = "Remove flags test";
+        const bool test_mode = true;
+
+        Window window(test_width, test_height, test_flags, test_title, test_mode);
+
+        SUBCASE("Remove all flags") {
+            CHECK(window.remove_flags(window.get_flags()));
+        }
+
+        SUBCASE("Remove a flag") {
+            CHECK(window.remove_flags(static_cast<ConfigFlags>(FLAG_FULLSCREEN_MODE)));
+
+            auto enabled_flags = window.get_enabled_flags();
+            CHECK_EQ(enabled_flags.size(), 2);
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "Run while minimized") != enabled_flags.end()));
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "V-Sync") != enabled_flags.end()));
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "Fullscreen") == enabled_flags.end()));
+        }
+
+        SUBCASE("Remove more than one flag but not all") {
+            CHECK(window.remove_flags(static_cast<ConfigFlags>(FLAG_VSYNC_HINT | FLAG_WINDOW_ALWAYS_RUN)));
+
+            auto enabled_flags = window.get_enabled_flags();
+            CHECK_EQ(enabled_flags.size(), 1);
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "Fullscreen") != enabled_flags.end()));
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "Run while minimized") == enabled_flags.end()));
+            CHECK((std::find(enabled_flags.begin(), enabled_flags.end(),
+                             "V-Sync") == enabled_flags.end()));
+        }
+    }
 }


### PR DESCRIPTION
FinalProject.Window:
Closes #6.
Added ability to set flags through the Window wrapper class.
